### PR TITLE
Avoid a spurious warning

### DIFF
--- a/R/qcc.R
+++ b/R/qcc.R
@@ -57,7 +57,8 @@ qcc <- function(data, type = c("xbar", "R", "S", "xbar.one", "p", "np", "c", "u"
   sd <- paste("sd.", type, sep = "")
   if (!exists(sd, mode="function"))
      stop(paste("function", sd, "is not defined!"))
-  if (missing(std.dev)) 
+  missing.std.dev <- missing(std.dev)
+  if (missing.std.dev)
      { std.dev <- NULL
        std.dev <- switch(type, 
                          "xbar" = { if(any(sizes > 25)) "RMSDF"
@@ -134,7 +135,7 @@ qcc <- function(data, type = c("xbar", "R", "S", "xbar.one", "p", "np", "c", "u"
                                       sizes = sizes, conf = conf)) 
      }
   else 
-     { if (!missing(std.dev))
+     { if (!missing.std.dev)
           warning("'std.dev' is not used when limits is given")
        if (!is.numeric(limits))
           stop("'limits' must be a vector of length 2 or a 2-columns matrix")

--- a/man/cusum.Rd
+++ b/man/cusum.Rd
@@ -9,8 +9,9 @@
 \description{Create an object of class 'cusum.qcc' to compute a Cusum chart for statistical quality control.}
 
 \usage{
-cusum(data, sizes, center, std.dev, decision.interval = 5, se.shift = 1,
-      data.name, labels, newdata, newsizes, newlabels, plot = TRUE, \dots)
+cusum(data, sizes, center, std.dev, head.start = 0,
+      decision.interval = 5, se.shift = 1, data.name, labels,
+      newdata, newsizes, newlabels, plot = TRUE, \dots)
 
 \method{print}{cusum.qcc}(x, \dots)
 
@@ -31,6 +32,11 @@ cusum(data, sizes, center, std.dev, decision.interval = 5, se.shift = 1,
 \item{std.dev}{a value or an available method specifying the within-group standard deviation(s) of the process. \cr
 Several methods are available for estimating the standard deviation. See \code{\link{sd.xbar}} and \code{\link{sd.xbar.one}} for, respectively, the grouped data case and the individual observations case.
 }
+
+\item{head.start}{The initializing value for the above-target and
+below-target cumulative sums, measured in standard errors of the summary
+statistics. Use zero for the traditional Cusum chart, or a positive
+value less than the \code{decision.interval} for a Fast Initial Response.}
 
 \item{decision.interval}{A numeric value specifying the number of standard errors of the summary statistics at which the cumulative sum is out of control.}
 

--- a/man/oc.curves.Rd
+++ b/man/oc.curves.Rd
@@ -2,6 +2,7 @@
 \alias{oc.curves}
 \alias{oc.curves.xbar}
 \alias{oc.curves.R}
+\alias{oc.curves.S}
 \alias{oc.curves.p}
 \alias{oc.curves.c}
 \title{Operating Characteristic Function}
@@ -13,6 +14,9 @@ oc.curves.xbar(object, n, c = seq(0, 5, length=101),
                nsigmas = object$nsigmas, identify=FALSE, restore.par=TRUE)
 
 oc.curves.R(object, n, c = seq(1, 6, length=101),
+            nsigmas = object$nsigmas, identify = FALSE, restore.par=TRUE)
+
+oc.curves.S(object, n, c = seq(1, 6, length=101),
             nsigmas = object$nsigmas, identify = FALSE, restore.par=TRUE)
 
 oc.curves.p(object, nsigmas = object$nsigmas, identify = FALSE, restore.par=TRUE)
@@ -35,11 +39,12 @@ is ignored for types "p" and "c".}
 \details{An operating characteristic curve graphically provides information about the probability of not detecting a shift in the process. \code{oc.curves} is a generic function which calls the proper function depending on the type of 'qcc' object. Further arguments provided through \dots are passed to the specific function depending on the type of chart.
 
 The probabilities are based on the conventional assumptions about
-process distributions: the normal distribution for "xbar" and
-"R", the binomial distribution for "p" and "np", and the Poisson distribution
+process distributions: the normal distribution for "xbar" , "R", and "S",
+the binomial distribution for "p" and "np", and the Poisson distribution
 for "c" and "u". They are all sensitive to departures from those assumptions,
-but to varying degrees. The performance of the "R" chart, in particular,
-is likely to be seriously affected by longer tails.}
+but to varying degrees. The performance of the "S" chart, and especially
+the "R" chart,
+are likely to be seriously affected by longer tails.}
 \value{The function invisibly returns a matrix or a vector of beta values, the probability of type II error.}
 \references{
 Mason, R.L. and Young, J.C. (2002) \emph{Multivariate Statistical Process Control with Industrial Applications}, SIAM. \cr


### PR DESCRIPTION
        * R/qcc.R (qcc): do not warn about !missing(std.dev) when it was
          originally missing.