### PR TITLE
added newdata.name variable and updated documentation

### DIFF
--- a/R/qcc.R
+++ b/R/qcc.R
@@ -15,7 +15,7 @@
 #  Main function to create a 'qcc' object
 #
 
-qcc <- function(data, type = c("xbar", "R", "S", "xbar.one", "p", "np", "c", "u", "g"), sizes, center, std.dev, limits, data.name, labels, newdata, newsizes, newlabels, nsigmas = 3, confidence.level, rules = shewhart.rules, plot = TRUE, ...)
+qcc <- function(data, type = c("xbar", "R", "S", "xbar.one", "p", "np", "c", "u", "g"), sizes, center, std.dev, limits, data.name, labels, newdata, newsizes, newdata.name, newlabels, nsigmas = 3, confidence.level, rules = shewhart.rules, plot = TRUE, ...)
 {
   call <- match.call()
   
@@ -85,7 +85,8 @@ qcc <- function(data, type = c("xbar", "R", "S", "xbar.one", "p", "np", "c", "u"
                  center = center, std.dev = std.dev)
   # check for new data provided and update object
   if (!missing(newdata))
-     { newdata.name <- deparse(substitute(newdata))
+     {   if (missing(newdata.name))
+			{newdata.name <- deparse(substitute(newdata))}
        newdata <- data.matrix(newdata)
        if (missing(newsizes))
           { if (any(type==c("p", "np", "u")))

--- a/man/qcc.Rd
+++ b/man/qcc.Rd
@@ -6,10 +6,10 @@
 \title{Quality Control Charts}
 \description{Create an object of class 'qcc' to perform statistical quality control. This object may then be used to plot Shewhart charts, drawing OC curves, computes capability indices, and more.}
 \usage{
-qcc(data, type, sizes, center, std.dev, limits, 
-    data.name, labels, newdata, newsizes, newlabels, 
-    nsigmas = 3, confidence.level, rules = shewhart.rules, 
-    plot = TRUE, \dots)
+qcc(data, type, sizes, center, std.dev, limits,
+    data.name, labels, newdata, newsizes, newdata.name,
+	newlabels, nsigmas = 3, confidence.level,
+	rules = shewhart.rules, plot = TRUE, \dots)
 
 \method{print}{qcc}(x, \dots)
 
@@ -59,6 +59,8 @@ Several methods are available for estimating the standard deviation in case of a
 \item{newdata}{a data frame, matrix or vector, as for the \code{data} argument, providing further data to plot but not included in the computations.}
 
 \item{newsizes}{a vector as for the \code{sizes} argument providing further data sizes to plot but not included in the computations.}
+
+\item{newdata.name}{a string specifying the name of the variable which appears on the plots. If not provided is taken from the object given as newdata.}
 
 \item{newlabels}{a character vector of labels for each new group defined in the argument \code{newdata}.}
 


### PR DESCRIPTION
I was having an issue where I needed to modify the newdata.name parameter when plotting a qcc object and was able to fix it very quickly. I have added these changes and updated the documentation to reflect the newly added parameter.