### PR TITLE
xlab as parameter in plot.processCapability.

### DIFF
--- a/R/capability.R
+++ b/R/capability.R
@@ -165,7 +165,7 @@ plot.processCapability <- function(x,
                                    breaks = "scott", 
                                    col = adjustcolor(qcc.options("zones")$fill, alpha.f = 0.5), 
                                    border = "white",
-                                   title, 
+                                   title, xlab,
                                    digits = getOption("digits"),
                                    restore.par = TRUE, ...) 
 {
@@ -203,7 +203,7 @@ plot.processCapability <- function(x,
             else          c(0, 0, 1.5*cex.labels, 0))
 
   plot(0, 0, type="n", xlim = xlim, ylim = ylim,
-       axes = FALSE, ylab="", xlab = object$data.name)
+       axes = FALSE, ylab="", xlab = if(missing(xlab)) object$data.name else xlab)
   usr <- par()$usr
   rect(usr[1], usr[3], usr[2], usr[4], col = qcc.options("bg.figure"))
   axis(1, cex.axis = par("cex.axis")*0.9)

--- a/man/processCapability.Rd
+++ b/man/processCapability.Rd
@@ -19,7 +19,7 @@ processCapability(object, spec.limits, target, std.dev, nsigmas,
      breaks = "scott", 
      col = adjustcolor(qcc.options("zones")$fill, alpha.f = 0.5), 
      border = "white",
-     title, 
+     title, xlab,
      digits = getOption("digits"),
      restore.par = TRUE, \dots)
 }
@@ -36,6 +36,7 @@ processCapability(object, spec.limits, target, std.dev, nsigmas,
 \item{breaks}{a value or string used to draw the histogram. See the help for  \code{\link{hist}} for more details.}
 \item{col, border}{values specifying the colour of the area and the border of the histogram.}
 \item{title}{a character string specifying the plot title. Set \code{title = FALSE} or \code{title = NA} to remove the title.}
+\item{xlab}{a character string specifying the label for the x-axis.}
 \item{print}{a logical value indicating whether statistics and capability indices should be printed.}
 \item{digits}{the number of significant digits to use.}
 \item{restore.par}{a logical value indicating whether the previous \code{par} settings must be restored. If you need to add points, lines, etc. to a chart set this to \code{FALSE}.}


### PR DESCRIPTION
Hello Luca,

I don't know if there is a specific reason why the plot.processCapability() function doesn't allow a custom xlab as, i.e., plot.qcc() or plot.ewma.qcc(), but I modified the two lines of code needed for that and added the changes to the documentation. 

Regards, Pablo.