### PR TITLE
Feat/diagnostics and capability refactor

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -73,6 +73,10 @@ export(qcc.options, qccGroups, blues.colors,
 export(describe, print.describe)
 S3method("print", "describe")
 
+export(qcc_diagnostics, print.qcc_diagnostics, plot.qcc_diagnostics)
+S3method("print", "qcc_diagnostics")
+S3method("plot", "qcc_diagnostics")
+
 # deprecated
 export(pareto.chart, process.capability, oc.curves, 
        qcc.groups, nclass.hist, cause.and.effect, 

--- a/R/capability.R
+++ b/R/capability.R
@@ -75,27 +75,31 @@ processCapability <- function(object, spec.limits, target,
   Pp.k <- min(Pp.u, Pp.l, na.rm = TRUE)
   Ppm <- Pp / sqrt(1+((center-target)/overall.std.dev)^2)
 
-  # compute confidence limits 
-  alpha <- 1-confidence.level
-  Cp.limits   <- .chisq_limits_cp_family(Cp, n - 1, alpha)
-  Cp.u.limits <- .wald_limits_cpk_family(Cp.u, qnorm(confidence.level), n)
-  Cp.l.limits <- .wald_limits_cpk_family(Cp.l, qnorm(confidence.level), n)
-  Cp.k.limits <- .wald_limits_cpk_family(Cp.k, qnorm(1 - alpha / 2), n)
-  df <- n * (1 + ((center - target) / std.dev)^2) / (1 + 2 * ((center - target) / std.dev)^2)
-  Cpm.limits <- .chisq_limits_cp_family(Cpm, df, alpha)
-  Pp.limits <- .chisq_limits_cp_family(Pp, n - 1, alpha)
-  Pp.u.limits <- .wald_limits_cpk_family(Pp.u, qnorm(confidence.level), n)
-  Pp.l.limits <- .wald_limits_cpk_family(Pp.l, qnorm(confidence.level), n)
-  Pp.k.limits <- .wald_limits_cpk_family(Pp.k, qnorm(1 - alpha / 2), n)
-  overall.df <- n * (1 + ((center - target) / overall.std.dev)^2) /
-    (1 + 2 * ((center - target) / overall.std.dev)^2)
-  Ppm.limits <- .chisq_limits_cp_family(Ppm, overall.df, alpha)
+  # compute confidence limits
+  alpha  <- 1 - confidence.level
+  z_one  <- qnorm(confidence.level)
+  z_two  <- qnorm(1 - alpha / 2)
 
-  limit.names <- c(paste(round(100*alpha/2, 1), "%", sep=""),
-                   paste(round(100*(1-alpha/2), 1), "%", sep=""))
-  names(Cp.limits) <- names(Cp.u.limits) <- names(Cp.l.limits) <- names(Cp.k.limits) <-
-    names(Cpm.limits) <- names(Pp.limits) <- names(Pp.u.limits) <- names(Pp.l.limits) <-
-    names(Pp.k.limits) <- names(Ppm.limits) <- limit.names
+  index_specs <- list(
+    Cp    = list(value = Cp,    fn = "chisq", arg = n - 1),
+    Cp_l  = list(value = Cp.l, fn = "wald",  arg = z_one),
+    Cp_u  = list(value = Cp.u, fn = "wald",  arg = z_one),
+    Cp_k  = list(value = Cp.k, fn = "wald",  arg = z_two),
+    Cpm   = list(value = Cpm,  fn = "chisq", arg = .cpm_df(n, center, target, std.dev)),
+    Pp    = list(value = Pp,   fn = "chisq", arg = n - 1),
+    Pp_l  = list(value = Pp.l, fn = "wald",  arg = z_one),
+    Pp_u  = list(value = Pp.u, fn = "wald",  arg = z_one),
+    Pp_k  = list(value = Pp.k, fn = "wald",  arg = z_two),
+    Ppm   = list(value = Ppm,  fn = "chisq", arg = .cpm_df(n, center, target, overall.std.dev))
+  )
+  limits_list <- lapply(index_specs, function(spec) {
+    if (spec$fn == "chisq")
+      .chisq_limits_cp_family(spec$value, spec$arg, alpha)
+    else
+      .wald_limits_cpk_family(spec$value, spec$arg, n)
+  })
+  limit.names <- c(paste0(round(100 * alpha / 2, 1), "%"),
+                   paste0(round(100 * (1 - alpha / 2), 1), "%"))
 
   if(is.na(LSL))  exp.LSL <- NA
   else { exp.LSL <- pnorm((LSL-center)/std.dev) * 100
@@ -106,13 +110,9 @@ processCapability <- function(object, spec.limits, target,
   obs.LSL <- sum(x<LSL)/n * 100
   obs.USL <- sum(x>USL)/n * 100
   
-  tab <- cbind(c(Cp, Cp.l, Cp.u, Cp.k, Cpm, Pp, Pp.l, Pp.u, Pp.k, Ppm),
-               rbind(Cp.limits, Cp.l.limits, Cp.u.limits, 
-                     Cp.k.limits, Cpm.limits, Pp.limits, Pp.l.limits, Pp.u.limits,
-                     Pp.k.limits, Ppm.limits))
-  rownames(tab) <- c("Cp", "Cp_l", "Cp_u", "Cp_k", "Cpm",
-                     "Pp", "Pp_l", "Pp_u", "Pp_k", "Ppm")
-  colnames(tab) <- c("Value", names(Cp.limits))
+  tab <- do.call(rbind,
+    Map(function(spec, lim) c(spec$value, lim), index_specs, limits_list))
+  colnames(tab) <- c("Value", limit.names)
 
   out <- list(data = x, data.name = object$data.name,
               center = center, std.dev = std.dev, overall.std.dev = overall.std.dev,
@@ -371,4 +371,12 @@ plot.processCapability <- function(x,
 {
   if (is.na(idx)) return(c(NA_real_, NA_real_))
   idx * sqrt(qchisq(c(alpha / 2, 1 - alpha / 2), df) / df)
+}
+
+# Satterthwaite degrees of freedom for Cpm / Ppm (Boyles 1991).
+# Same formula for both; differs only in which sigma is passed.
+.cpm_df <- function(n, center, target, sigma)
+{
+  k <- ((center - target) / sigma)^2
+  n * (1 + k) / (1 + 2 * k)
 }

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1,0 +1,248 @@
+#' Supplementary non-randomness diagnostics for qcc charts
+#'
+#' Detects patterns 5-8 from Nelson (1984) as a post-hoc analysis on an
+#' existing \code{qcc} object. The original object and its \code{$violations}
+#' field are never modified.
+#'
+#' @param object An object of class \code{"qcc"}.
+#' @param pattern5 Logical. If \code{TRUE}, detect 15 consecutive points in
+#'   Zone C (stratification signal).
+#' @param pattern6 Logical. If \code{TRUE}, detect 8 consecutive points
+#'   outside Zone C (mixture signal).
+#' @param pattern7 Logical. If \code{TRUE}, detect 14 consecutive alternating
+#'   points (oscillation signal).
+#' @param pattern8 Logical. If \code{TRUE}, detect 7 consecutive trending
+#'   points (drift signal).
+#'
+#' @return An object of class \code{"qcc_diagnostics"} containing:
+#'   \item{qcc_object}{the original \code{qcc} object, unmodified}
+#'   \item{stats}{full statistics vector (phase I + phase II)}
+#'   \item{zone_c}{matrix of Zone C limits (±1σ) per observation}
+#'   \item{pattern5}{integer vector of violation indices, or \code{NULL} if
+#'     not requested}
+#'   \item{pattern6}{integer vector of violation indices, or \code{NULL} if
+#'     not requested}
+#'   \item{pattern7}{integer vector of violation indices, or \code{NULL} if
+#'     not requested}
+#'   \item{pattern8}{integer vector of violation indices, or \code{NULL} if
+#'     not requested}
+#'
+#' @references
+#' Nelson, L.S. (1984). The Shewhart Control Chart: Tests for Special Causes.
+#' \emph{Journal of Quality Technology} 16(4), 237-239.
+#'
+#' Montgomery, D.C. (2009). \emph{Introduction to Statistical Quality Control},
+#' 6th ed. Wiley. Section 5.4.
+#'
+#' @seealso \code{\link{qcc}}, \code{\link{qccRules}}
+#'
+#' @export
+qcc_diagnostics <- function(object,
+                              pattern5 = FALSE,
+                              pattern6 = FALSE,
+                              pattern7 = FALSE,
+                              pattern8 = FALSE)
+{
+  if (!inherits(object, "qcc"))
+    stop("'object' must be of class 'qcc'")
+
+  s      <- c(object$statistics, object$newstats)
+  zone_c <- .qcc_zone_c(object)
+
+  result <- list(
+    qcc_object = object,
+    stats      = s,
+    zone_c     = zone_c,
+    pattern5   = if (pattern5) .detect_p5(s, zone_c) else NULL,
+    pattern6   = if (pattern6) .detect_p6(s, zone_c) else NULL,
+    pattern7   = if (pattern7) .detect_p7(s)          else NULL,
+    pattern8   = if (pattern8) .detect_p8(s)          else NULL,
+    call       = match.call()
+  )
+  class(result) <- "qcc_diagnostics"
+  result
+}
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# Compute Zone C limits (±1σ) for all observations using the same
+# limits.<type>() infrastructure as the rest of the package.
+.qcc_zone_c <- function(object)
+{
+  all_sizes <- c(object$sizes, object$newsizes)
+  limits_fn <- paste0("limits.", object$type)
+  if (!exists(limits_fn, mode = "function"))
+    stop(paste("function", limits_fn, "is not defined"))
+
+  zone_c <- do.call(limits_fn,
+                    list(center  = object$center,
+                         std.dev = object$std.dev,
+                         sizes   = all_sizes,
+                         nsigmas = object$nsigmas * (1 / 3)))
+
+  # When limits are fixed (1 row), expand to full series length
+  n <- length(c(object$statistics, object$newstats))
+  if (nrow(zone_c) == 1L)
+    zone_c <- zone_c[rep(1L, n), , drop = FALSE]
+
+  zone_c
+}
+
+# embed()-based window detector: returns indices of the LAST point in every
+# window where all run_len values satisfy the condition.
+.run_all_true <- function(condition, run_len)
+{
+  if (length(condition) < run_len) return(integer(0L))
+  windows <- embed(condition, run_len)
+  as.integer(which(rowSums(windows) == run_len) + (run_len - 1L))
+}
+
+# ---------------------------------------------------------------------------
+# Pattern detectors
+# ---------------------------------------------------------------------------
+
+# Pattern 5: 15 consecutive points in Zone C (stratification)
+.detect_p5 <- function(s, zone_c, run_len = 15L)
+{
+  in_c <- s >= zone_c[, 1] & s <= zone_c[, 2]
+  .run_all_true(in_c, run_len)
+}
+
+# Pattern 6: 8 consecutive points outside Zone C (mixture)
+.detect_p6 <- function(s, zone_c, run_len = 8L)
+{
+  out_c <- s < zone_c[, 1] | s > zone_c[, 2]
+  .run_all_true(out_c, run_len)
+}
+
+# Pattern 7: 14 consecutive alternating points (oscillation)
+# 14 alternating points require 13 consecutive differences and 12 consecutive
+# sign-change pairs in those differences.
+.detect_p7 <- function(s, run_len = 14L)
+{
+  n <- length(s)
+  if (n < run_len) return(integer(0L))
+  diffs    <- diff(s)
+  # TRUE where consecutive differences have opposite signs (product < 0)
+  sign_alt <- diffs[-length(diffs)] * diffs[-1] < 0
+  n_pairs  <- run_len - 2L   # 12 consecutive sign-change pairs needed
+  if (length(sign_alt) < n_pairs) return(integer(0L))
+  # .run_all_true returns the last index in sign_alt for each window.
+  # sign_alt[j] involves s[j] through s[j+2], so the last point of the
+  # 14-point window in s is 2 positions beyond the last sign_alt index.
+  as.integer(.run_all_true(sign_alt, n_pairs) + 2L)
+}
+
+# Pattern 8: 7 consecutive trending points (drift)
+# 7 points in a strictly monotone sequence require 6 same-sign differences.
+.detect_p8 <- function(s, run_len = 7L)
+{
+  n <- length(s)
+  if (n < run_len) return(integer(0L))
+  diffs <- diff(s)
+  steps <- run_len - 1L   # 6 same-sign differences needed
+  hits  <- c(.run_all_true(diffs > 0, steps),
+             .run_all_true(diffs < 0, steps))
+  as.integer(sort(unique(hits)))
+}
+
+# ---------------------------------------------------------------------------
+# S3 methods
+# ---------------------------------------------------------------------------
+
+#' @export
+print.qcc_diagnostics <- function(x, ...)
+{
+  object <- x
+  cat(cli::rule(left = crayon::bold("QCC Supplementary Diagnostics"),
+                width = min(getOption("width"), 50L)), "\n\n")
+
+  desc <- c(
+    "5" = "15 consecutive in Zone C     (stratification)",
+    "6" = "8 consecutive outside Zone C (mixture)",
+    "7" = "14 consecutive alternating   (oscillation)",
+    "8" = "7 consecutive trending       (drift)"
+  )
+
+  for (pid in c("5", "6", "7", "8")) {
+    idx   <- object[[paste0("pattern", pid)]]
+    label <- paste0("Pattern ", pid, " — ", desc[pid])
+    if (is.null(idx)) {
+      cat(label, "\n  not requested\n\n")
+    } else if (length(idx) == 0L) {
+      cat(label, "\n  no violations detected\n\n")
+    } else {
+      cat(label, "\n")
+      cat("  ", length(idx), "violation(s) at index(es):",
+          paste(idx, collapse = ", "), "\n\n")
+    }
+  }
+  invisible(object)
+}
+
+#' @export
+plot.qcc_diagnostics <- function(x,
+                                  xtime     = NULL,
+                                  add.stats = qcc.options("add.stats"),
+                                  title, xlab, ylab, xlim, ylim,
+                                  digits    = getOption("digits"), ...)
+{
+  object  <- x
+  qcc_obj <- object$qcc_object
+  s       <- object$stats
+
+  # x-axis positions must mirror plot.qcc() logic
+  groups <- if (is.null(xtime)) seq_along(s) else xtime
+
+  # Build base chart via plot.qcc
+  base_args <- list(x         = qcc_obj,
+                    xtime     = xtime,
+                    add.stats = add.stats,
+                    digits    = digits)
+  if (!missing(title)) base_args$title <- title
+  if (!missing(xlab))  base_args$xlab  <- xlab
+  if (!missing(ylab))  base_args$ylab  <- ylab
+  if (!missing(xlim))  base_args$xlim  <- xlim
+  if (!missing(ylim))  base_args$ylim  <- ylim
+  p <- do.call(plot, base_args)
+
+  # Visual encoding: color + shape per pattern (distinct from WER markers)
+  patt_col   <- c("5" = "#E69F00", "6" = "#9370DB",
+                   "7" = "#228B22", "8" = "#C0392B")
+  patt_shape <- c("5" = 24L, "6" = 23L, "7" = 4L, "8" = 15L)
+  patt_label <- c("5" = "P5: 15 in Zone C",
+                   "6" = "P6: 8 outside Zone C",
+                   "7" = "P7: 14 alternating",
+                   "8" = "P8: 7 trending")
+
+  caption_parts <- character(0L)
+
+  for (pid in c("5", "6", "7", "8")) {
+    idx <- object[[paste0("pattern", pid)]]
+    if (is.null(idx)) next
+
+    n_viol <- length(idx)
+    caption_parts <- c(caption_parts,
+                        paste0(patt_label[pid], " [", n_viol, "]"))
+    if (n_viol == 0L) next
+
+    vdf <- data.frame(x = groups[idx], y = s[idx])
+    p[[1]] <- p[[1]] +
+      ggplot2::geom_point(
+        data    = vdf,
+        mapping = ggplot2::aes(x = .data[["x"]], y = .data[["y"]]),
+        colour  = unname(patt_col[pid]),
+        shape   = unname(patt_shape[pid]),
+        size    = 3,
+        stroke  = 1.2
+      )
+  }
+
+  if (length(caption_parts) > 0L)
+    p[[1]] <- p[[1]] +
+      ggplot2::labs(caption = paste(caption_parts, collapse = "   "))
+
+  p
+}

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -1,0 +1,222 @@
+test_that("qcc_diagnostics rejects non-qcc input", {
+  expect_error(qcc_diagnostics(list()), "'object' must be of class 'qcc'")
+  expect_error(qcc_diagnostics("not a qcc"), "'object' must be of class 'qcc'")
+})
+
+test_that("inactive patterns return NULL and do not compute", {
+  q  <- qcc(rep(0, 20), type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q)
+  expect_null(dx$pattern5)
+  expect_null(dx$pattern6)
+  expect_null(dx$pattern7)
+  expect_null(dx$pattern8)
+})
+
+test_that("original qcc object is not modified", {
+  q              <- qcc(c(-2, 2, rep(0, 15), 2, -2, 2),
+                        type = "xbar.one", center = 0, std.dev = 1)
+  orig_viol      <- q$violations
+  orig_stats     <- q$statistics
+  orig_center    <- q$center
+  orig_std.dev   <- q$std.dev
+  dx             <- qcc_diagnostics(q, pattern5 = TRUE, pattern8 = TRUE)
+  expect_identical(q$violations, orig_viol)
+  expect_identical(q$statistics, orig_stats)
+  expect_identical(q$center,     orig_center)
+  expect_identical(q$std.dev,    orig_std.dev)
+  expect_identical(dx$qcc_object$violations, orig_viol)
+})
+
+test_that("result has class qcc_diagnostics", {
+  q  <- qcc(rnorm(20), type = "xbar.one")
+  dx <- qcc_diagnostics(q, pattern8 = TRUE)
+  expect_s3_class(dx, "qcc_diagnostics")
+})
+
+# ---------------------------------------------------------------------------
+# Pattern 5 — 15 consecutive in Zone C
+# center=0, std.dev=1, nsigmas=3  →  Zone C = [-1, 1]
+# Series: 2 outside points, 15 in Zone C, 3 outside points
+# First all-in-Zone-C window ends at position 17
+# ---------------------------------------------------------------------------
+
+test_that("pattern5 detects 15 consecutive in Zone C", {
+  s  <- c(-2, 2, rep(0, 15), 2, -2, 2)
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern5 = TRUE)
+  expect_type(dx$pattern5, "integer")
+  expect_equal(dx$pattern5, 17L)
+})
+
+test_that("pattern5 returns integer(0) when no run of 15 in Zone C", {
+  # All points outside Zone C
+  s  <- rep(c(2, -2), 10)
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern5 = TRUE)
+  expect_equal(dx$pattern5, integer(0L))
+})
+
+test_that("pattern5 returns integer(0) for series shorter than 15", {
+  s  <- rep(0, 14)
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern5 = TRUE)
+  expect_equal(dx$pattern5, integer(0L))
+})
+
+# ---------------------------------------------------------------------------
+# Pattern 6 — 8 consecutive outside Zone C
+# Series: 5 in Zone C, 8 outside, 5 in Zone C
+# First all-outside window ends at position 13
+# ---------------------------------------------------------------------------
+
+test_that("pattern6 detects 8 consecutive outside Zone C", {
+  s  <- c(rep(0, 5), rep(2, 8), rep(0, 5))
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern6 = TRUE)
+  expect_type(dx$pattern6, "integer")
+  expect_equal(dx$pattern6, 13L)
+})
+
+test_that("pattern6 detects run on negative side", {
+  s  <- c(rep(0, 5), rep(-2, 8), rep(0, 5))
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern6 = TRUE)
+  expect_equal(dx$pattern6, 13L)
+})
+
+test_that("pattern6 returns integer(0) when no run of 8 outside Zone C", {
+  s  <- rep(0, 20)
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern6 = TRUE)
+  expect_equal(dx$pattern6, integer(0L))
+})
+
+test_that("pattern6 returns integer(0) for series shorter than 8", {
+  s  <- rep(2, 7)
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern6 = TRUE)
+  expect_equal(dx$pattern6, integer(0L))
+})
+
+# ---------------------------------------------------------------------------
+# Pattern 7 — 14 consecutive alternating points
+# Series: 5 zeros + 14 alternating (3,-3 repeated) + 5 zeros
+# Alternating region at positions 6-19; detections within that range
+# ---------------------------------------------------------------------------
+
+test_that("pattern7 detects 14 consecutive alternating points", {
+  s  <- c(rep(0, 5), rep(c(3, -3), 7), rep(0, 5))
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern7 = TRUE)
+  expect_type(dx$pattern7, "integer")
+  expect_gt(length(dx$pattern7), 0L)
+  expect_true(all(dx$pattern7 >= 18L & dx$pattern7 <= 20L))
+})
+
+test_that("pattern7 returns integer(0) for monotone series", {
+  # Strictly increasing: no alternation at all
+  s  <- 1:25
+  q  <- qcc(s, type = "xbar.one", center = 13, std.dev = 5)
+  dx <- qcc_diagnostics(q, pattern7 = TRUE)
+  expect_equal(dx$pattern7, integer(0L))
+})
+
+test_that("pattern7 returns integer(0) for series shorter than 14", {
+  s  <- rep(c(1, -1), 6)   # 12 points
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern7 = TRUE)
+  expect_equal(dx$pattern7, integer(0L))
+})
+
+# ---------------------------------------------------------------------------
+# Pattern 8 — 7 consecutive trending points
+# Series: 5 zeros + 7 strictly increasing + 5 zeros  (17 points)
+# diffs[5:10] all positive → window ends at index 11
+# ---------------------------------------------------------------------------
+
+test_that("pattern8 detects 7 consecutive upward trend", {
+  s  <- c(rep(0, 5), 1:7, rep(0, 5))
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern8 = TRUE)
+  expect_type(dx$pattern8, "integer")
+  expect_true(11L %in% dx$pattern8)
+})
+
+test_that("pattern8 detects 7 consecutive downward trend", {
+  s  <- c(rep(0, 5), 7:1, rep(0, 5))
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern8 = TRUE)
+  expect_true(11L %in% dx$pattern8)
+})
+
+test_that("pattern8 returns integer(0) for flat series", {
+  s  <- rep(0, 20)
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern8 = TRUE)
+  expect_equal(dx$pattern8, integer(0L))
+})
+
+test_that("pattern8 returns integer(0) for series shorter than 7", {
+  s  <- 1:6
+  q  <- qcc(s, type = "xbar.one", center = 3.5, std.dev = 2)
+  dx <- qcc_diagnostics(q, pattern8 = TRUE)
+  expect_equal(dx$pattern8, integer(0L))
+})
+
+test_that("pattern8 does not trigger on trend broken by a tie", {
+  # 6 increasing then a repeat (tie breaks the run)
+  s  <- c(rep(0, 5), 1, 2, 3, 4, 5, 5, 6, rep(0, 5))
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern8 = TRUE)
+  # The run 1,2,3,4,5 is only 5 points; the run after the tie has fewer than 7
+  expect_equal(dx$pattern8, integer(0L))
+})
+
+# ---------------------------------------------------------------------------
+# Zone C infrastructure
+# ---------------------------------------------------------------------------
+
+test_that("Zone C limits are strictly inside control limits", {
+  q      <- qcc(rnorm(30), type = "xbar.one")
+  dx     <- qcc_diagnostics(q, pattern5 = TRUE)
+  zone_c <- dx$zone_c
+  lcl    <- q$limits[, 1]
+  ucl    <- q$limits[, 2]
+  expect_true(all(zone_c[, 1] > lcl))
+  expect_true(all(zone_c[, 2] < ucl))
+})
+
+test_that("Zone C is symmetric around center", {
+  q      <- qcc(rnorm(30), type = "xbar.one")
+  dx     <- qcc_diagnostics(q, pattern5 = TRUE)
+  zone_c <- dx$zone_c
+  center <- q$center
+  expect_equal(zone_c[, 2] - center, center - zone_c[, 1], tolerance = 1e-10)
+})
+
+# ---------------------------------------------------------------------------
+# Phase II (newdata) support
+# ---------------------------------------------------------------------------
+
+test_that("stats field concatenates phase I and phase II", {
+  s1 <- rnorm(20)
+  s2 <- rnorm(10)
+  q  <- qcc(s1, type = "xbar.one", newdata = s2)
+  dx <- qcc_diagnostics(q, pattern8 = TRUE)
+  expect_equal(length(dx$stats), 30L)
+})
+
+# ---------------------------------------------------------------------------
+# Multiple patterns simultaneously
+# ---------------------------------------------------------------------------
+
+test_that("multiple patterns can be requested in a single call", {
+  s  <- c(-2, 2, rep(0, 15), 2, -2, 2)
+  q  <- qcc(s, type = "xbar.one", center = 0, std.dev = 1)
+  dx <- qcc_diagnostics(q, pattern5 = TRUE, pattern6 = TRUE,
+                          pattern7 = TRUE, pattern8 = TRUE)
+  expect_type(dx$pattern5, "integer")
+  expect_type(dx$pattern6, "integer")
+  expect_type(dx$pattern7, "integer")
+  expect_type(dx$pattern8, "integer")
+})


### PR DESCRIPTION
## Summary

  - Add `qcc_diagnostics()`: post-hoc detection of Nelson non-randomness patterns 5–8
    on an existing `qcc` object without modifying it or its `$violations` field
  - Refactor `processCapability()`: consolidate the ten individual CI computations
    into a single `index_specs` list dispatched by `lapply` + `Map`

  ## Changes

  **`R/diagnostics.R`** (new)
  - `qcc_diagnostics(object, pattern5, pattern6, pattern7, pattern8)` — all patterns
    default to `FALSE`; Zone C limits derived via existing `limits.<type>()` infrastructure
  - `print.qcc_diagnostics()` and `plot.qcc_diagnostics()` S3 methods
  - Detection uses `embed()`-based sliding windows, no explicit loops

  **`R/capability.R`**
  - Replace 10 individual `<name>.limits` assignments + chained `names()` + manual
    `cbind/rbind` with a declarative `index_specs` list
  - Extract `.cpm_df()` helper: Satterthwaite df formula was duplicated for Cpm and Ppm
  - No change to public API or numerical results

  **`NAMESPACE`**
  - Export `qcc_diagnostics`, `print.qcc_diagnostics`, `plot.qcc_diagnostics`

  ## Test plan

  - [ ] `R CMD check` passes (CI)
  - [x] `tests/testthat/test-diagnostics.R` — positive, negative and edge-case tests
    for each of the 4 patterns, Zone C symmetry, phase II support
  - [ ] Existing `tests/testthat/test-capability.R` — numerical output unchanged