### PR TITLE
Small Refactors and Fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(person("Luca", "Scrucca", role = c("aut", "cre", "cph"),
              person("Peter", "Bloomfield", role = "ctb",
                     email = "Peter_Bloomfield@ncsu.edu"))
 Depends: 
-  R (>= 4.0), 
+  R (>= 4.1), 
   ggplot2 (>= 4.0),
   patchwork (>= 1.3)
 Imports: 

--- a/R/capability.R
+++ b/R/capability.R
@@ -234,15 +234,7 @@ plot.processCapability <- function(x,
          x = if(missing(xlab)) object$data.name else xlab) +
     coord_cartesian(xlim = xlim, ylim = ylim,
                     expand = FALSE, clip = "off") +
-    theme_light() + 
-    theme(plot.background = element_rect(fill = qcc.options("bg.margin"),
-                                         color = qcc.options("bg.margin")),
-          panel.background = element_rect(fill = qcc.options("bg.figure")),
-          plot.title = element_text(face = "bold", size = 11),
-          plot.margin = margin(5, 5, 5, 5),
-          axis.text.y = element_text(angle = 90, 
-                                     margin = margin(l = 5, r = 5),
-                                     hjust = 0.5, vjust = 0.5))
+    theme_qcc(plot.margin = margin(5, 5, 5, 5)) 
   
   plot <- plot +
     geom_vline(xintercept = object$spec.limits, lty = 2) +

--- a/R/cusum.R
+++ b/R/cusum.R
@@ -36,7 +36,7 @@ cusum <- function(data,
   if(ncol(data) == 1 & any(sizes > 1) & missing(std.dev))
      stop("sizes larger than 1 but data appears to be single samples. In this case you must provide also the std.dev")
   
-  labels <- if(is.null(rownames(data))) 1:nrow(data) else rownames(data)
+  labels <- rownames(data) %||% 1:nrow(data)
 
   stats <- paste("stats.", type, sep = "")
   if(!exists(stats, mode="function"))
@@ -250,7 +250,7 @@ plot.cusum.qcc <- function(x, xtime = NULL,
   cusum.pos <- object$pos
   cusum.neg <- object$neg
   statistics <- c(stats, newstats)
-  groups <- if(is.null(xtime)) 1:length(statistics) else xtime
+  groups <- xtime %||% 1:length(statistics)
   stopifnot(length(groups) == length(statistics))
   
   if(missing(title))

--- a/R/cusum.R
+++ b/R/cusum.R
@@ -18,7 +18,7 @@ cusum <- function(data,
   data <- data.matrix(data)
 
   if(missing(sizes)) 
-    { sizes <- apply(data, 1, function(x) sum(!is.na(x)))  }
+    { sizes <- as.integer(rowSums(!is.na(data)))  }
   else
     { if(length(sizes)==1)
          sizes <- rep(sizes, nrow(data))
@@ -77,7 +77,7 @@ cusum <- function(data,
     newdata <- data.matrix(newdata)
     if(missing(newsizes))
     { 
-      newsizes <- apply(newdata, 1, function(x) sum(!is.na(x))) 
+      newsizes <- as.integer(rowSums(!is.na(newdata)))
     } else
     { 
       if(length(newsizes)==1)
@@ -439,4 +439,3 @@ plot.cusum.qcc <- function(x, xtime = NULL,
   # class(plot) <- c("qccplot", class(plot))
   return(plot)
 }
-

--- a/R/cusum.R
+++ b/R/cusum.R
@@ -303,17 +303,11 @@ plot.cusum.qcc <- function(x, xtime = NULL,
     coord_cartesian(xlim = xlim+c(-0.5,0.5), 
                     ylim = extendrange(ylim),
                     expand = FALSE, clip = "off") +
-    theme_light() + 
-    theme(plot.background = element_rect(fill = qcc.options("bg.margin"),
-                                         color = qcc.options("bg.margin")),
-          panel.background = element_rect(fill = qcc.options("bg.figure")),
-          plot.title = element_text(face = "bold", size = 11),
-          axis.title.y = element_text(margin = margin(t = 0, r = 30, b = 0, l = 0)),
-          legend.position = "none",
-          plot.margin = margin(5, 30, 5, 5),
-          axis.text.y = element_text(angle = 90, 
-                                     margin = margin(l = 5, r = 5),
-                                     hjust = 0.5, vjust = 0.5))
+    theme_qcc(
+      axis.title.y = element_text(
+        margin = margin(t = 0, r = 30, b = 0, l = 0)
+      ),
+    ) 
   
   plot <- plot + 
   {

--- a/R/ewma.R
+++ b/R/ewma.R
@@ -310,16 +310,7 @@ plot.ewma.qcc <- function(x, xtime = NULL,
     coord_cartesian(xlim = xlim+c(-0.5,0.5), 
                     ylim = extendrange(ylim),
                     expand = FALSE, clip = "off") +
-    theme_light() + 
-    theme(plot.background = element_rect(fill = qcc.options("bg.margin"),
-                                         color = qcc.options("bg.margin")),
-          panel.background = element_rect(fill = qcc.options("bg.figure")),
-          plot.title = element_text(face = "bold", size = 11),
-          legend.position = "none",
-          plot.margin = margin(5, 30, 5, 5),
-          axis.text.y = element_text(angle = 90, 
-                                     margin = margin(l = 5, r = 5),
-                                     hjust = 0.5, vjust = 0.5))
+      theme_qcc()
   
   plot <- plot + 
   {

--- a/R/ewma.R
+++ b/R/ewma.R
@@ -58,7 +58,7 @@ ewma <- function(data,
   # used for computing statistics and std.dev
   type <- if(any(sizes==1)) "xbar.one" else "xbar"
 
-  labels <- if(is.null(rownames(data))) 1:nrow(data) else rownames(data)
+  labels <- rownames(data) %||% 1:nrow(data)
 
   stats <- paste("stats.", type, sep = "")
   if(!exists(stats, mode="function"))
@@ -264,7 +264,7 @@ plot.ewma.qcc <- function(x, xtime = NULL,
   newdata.name <- object$newdata.name
   violations <- object$violations
   statistics <- c(stats, newstats)
-  groups <- if(is.null(xtime)) 1:length(statistics) else xtime
+  groups <- xtime %||% 1:length(statistics)
   stopifnot(length(groups) == length(statistics))
 
   if(missing(title))

--- a/R/ewma.R
+++ b/R/ewma.R
@@ -49,7 +49,7 @@ ewma <- function(data,
   data <- data.matrix(data)
 
   if(missing(sizes)) 
-    { sizes <- apply(data, 1, function(x) sum(!is.na(x)))  }
+    { sizes <- as.integer(rowSums(!is.na(data)))  }
   else
     { if(length(sizes)==1)
          sizes <- rep(sizes, nrow(data))
@@ -99,7 +99,7 @@ ewma <- function(data,
     newdata <- data.matrix(newdata)
     if(missing(newsizes))
     { 
-      newsizes <- apply(newdata, 1, function(x) sum(!is.na(x))) 
+      newsizes <- as.integer(rowSums(!is.na(newdata)))
     } else
     { 
       if(length(newsizes)==1)

--- a/R/mqcc.R
+++ b/R/mqcc.R
@@ -279,8 +279,7 @@ plot.mqcc <- function(x,
   rect(par("usr")[1], par("usr")[3], par("usr")[2], par("usr")[4], 
        col = qcc.options("bg.figure"))
   axis(1, at = indices, las = axes.las,
-       labels = if(is.null(names(statistics))) 
-                   as.character(indices) else names(statistics),
+       labels = names(statistics) %||% as.character(indices),
        cex.axis = par("cex.axis")*0.9)
   axis(2, las = axes.las, cex.axis = par("cex.axis")*0.9)
   box()

--- a/R/mqcc.R
+++ b/R/mqcc.R
@@ -583,7 +583,7 @@ stats.T2.single <- function(data, center = NULL, cov = NULL)
   p <- ncol(data)                       # num. of variables
   n <- 1                                # samples sizes
   if(is.null(center))
-    { center <- apply(data, 2, mean) }  # overall mean
+    { center <- colMeans(data) }  # overall mean
   x <- scale(data, center = center, scale = FALSE)
   if(is.null(cov))
     { cov <- crossprod(x)/(m-1) }       # sample covar matrix

--- a/R/plot_helpers.R
+++ b/R/plot_helpers.R
@@ -1,0 +1,20 @@
+theme_qcc <- function(...) {
+  bg_margin <- qcc.options("bg.margin")
+  bg_figure <- qcc.options("bg.figure")
+
+  theme_light() +
+    theme(
+      plot.background = element_rect(fill = bg_margin, color = bg_margin),
+      panel.background = element_rect(fill = bg_figure),
+      plot.title = element_text(face = "bold", size = 11),
+      legend.position = "none",
+      plot.margin = margin(5, 30, 5, 5),
+      axis.text.y = element_text(
+        angle = 90,
+        margin = margin(l = 5, r = 5),
+        hjust = 0.5,
+        vjust = 0.5
+      )
+    ) +
+    theme(...)
+}

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -682,18 +682,18 @@ limits.xbar <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
     stop("Argument 'nsigmas' or 'conf' must be provided. See help.")
   if (length(unique(sizes))==1) sizes <- sizes[1]
   se.stats <- std.dev/sqrt(sizes)
-  if(is.null(conf))
-     { lcl <- center - nsigmas * se.stats
-       ucl <- center + nsigmas * se.stats
-     }
-  else 
-     { if (conf > 0 & conf < 1) 
-          { nsigmas <- qnorm(1 - (1 - conf)/2)
-            lcl <- center - nsigmas * se.stats
-            ucl <- center + nsigmas * se.stats
-          }
-       else stop("invalid 'conf' argument. See help.")
-     }
+
+  if (!is.null(conf)) {
+    if (!is.numeric(conf) || length(conf) != 1L || conf <= 0 || conf >= 1) {
+      stop("invalid 'conf' argument. See help.")
+    }
+
+    nsigmas <- qnorm(1 - (1 - conf) / 2)
+  }
+
+  delta <- nsigmas * se.stats
+  lcl <- center - delta
+  ucl <- center + delta
   .construct_limits(lcl,ucl)
 }
 
@@ -831,18 +831,18 @@ limits.xbar.one <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
   if(is.null(nsigmas) & is.null(conf))
     stop("Argument 'nsigmas' or 'conf' must be provided. See help.")
   se.stats <- std.dev
-  if (is.null(conf)) 
-     { lcl <- center - nsigmas * se.stats
-       ucl <- center + nsigmas * se.stats
-     }
-  else 
-     { if (conf > 0 & conf < 1) 
-          { nsigmas <- qnorm(1 - (1 - conf)/2)
-            lcl <- center - nsigmas * se.stats
-            ucl <- center + nsigmas * se.stats
-          }
-       else stop("invalid conf argument. See help.")
-     }
+
+  if (!is.null(conf)) {
+    if (!is.numeric(conf) || length(conf) != 1L || conf <= 0 || conf >= 1) {
+      stop("invalid 'conf' argument. See help.")
+    }
+
+    nsigmas <- qnorm(1 - (1 - conf) / 2)
+  }
+
+  delta <- nsigmas * se.stats
+  lcl <- center - delta
+  ucl <- center + delta
   .construct_limits(lcl,ucl)
 }
 

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -51,7 +51,7 @@ qcc <- function(data,
        else if (length(sizes) != nrow(data))
                 stop("sizes length doesn't match with data") }
 
-  labels <- if(is.null(rownames(data))) 1:nrow(data) else rownames(data)
+  labels <- rownames(data) %||% 1:nrow(data)
 
   stats <- paste("stats.", type, sep = "")
   if (!exists(stats, mode="function"))
@@ -298,11 +298,10 @@ plot.qcc <- function(x, xtime = NULL,
   newdata.name <- object$newdata.name
   violations <- object$violations
   rules <- object$rules
-  rule.set <- object$rule.set
-  if(is.null(rule.set)) rule.set <- "western-electric"
+  rule.set <- object$rule.set %||% "western-electric"
   rule.set <- match.arg(rule.set, c("western-electric", "nelson"))
   statistics <- c(stats, newstats)
-  groups <- if(is.null(xtime)) 1:length(statistics) else xtime
+  groups <- xtime %||% 1:length(statistics)
   stopifnot(length(groups) == length(statistics))
   
   if(missing(title))

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -819,6 +819,7 @@ sd.xbar.one <- function(data, sizes, std.dev = c("MR", "SD"), r = 2, ...)
                           d <- d+abs(diff(range(data[c(j:(j-r+1))], na.rm=TRUE)))
                       sd <- (d/(n-r+1))/d2[r] },
              "SD" = { sd <- sd(data)/qcc.c4(n) },
+             # "SD" = { sd <- sd(data, na.rm = TRUE)/qcc.c4(sum(!is.na(data))) }, # FIX: This handles NAs
              sd <- NULL)
     }
   return(sd)

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -356,16 +356,7 @@ plot.qcc <- function(x, xtime = NULL,
          y = if(missing(ylab)) "Group summary statistics" else ylab) +
     coord_cartesian(xlim = xlim, ylim = ylim,
                     expand = FALSE, clip = "off") +
-    theme_light() + 
-    theme(plot.background = element_rect(fill = qcc.options("bg.margin"),
-                                         color = qcc.options("bg.margin")),
-          panel.background = element_rect(fill = qcc.options("bg.figure")),
-          plot.title = element_text(face = "bold", size = 11),
-          legend.position = "none",
-          plot.margin = margin(5, 30, 5, 5),
-          axis.text.y = element_text(angle = 90, 
-                                     margin = margin(l = 5, r = 5),
-                                     hjust = 0.5, vjust = 0.5))
+    theme_qcc()
 
   plot <- plot + 
   {

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -44,7 +44,7 @@ qcc <- function(data,
      { if (any(type==c("p", "np", "u")))
           stop(paste("sample 'sizes' must be given for a", type, "Chart"))
        else
-          sizes <- apply(data, 1, function(x) sum(!is.na(x)))  }
+          sizes <- as.integer(rowSums(!is.na(data))) }
   else
      { if (length(sizes)==1)
           sizes <- rep(sizes, nrow(data))
@@ -106,7 +106,7 @@ qcc <- function(data,
       if(any(type==c("p", "np", "u")))
         stop(paste("sample 'newsizes' must be given for a", type, "Chart"))
       else
-        newsizes <- apply(newdata, 1, function(x) sum(!is.na(x))) 
+        newsizes <- as.integer(rowSums(!is.na(newdata)))
     } else
     { 
       if(length(newsizes)==1)
@@ -619,8 +619,8 @@ stats.xbar <- function(data, sizes)
 {
   data <- as.matrix(data)
   if(missing(sizes))
-    sizes <- apply(data, 1, function(x) sum(!is.na(x)))
-  statistics <- apply(data, 1, mean, na.rm=TRUE)
+    sizes <- as.integer(rowSums(!is.na(data)))
+  statistics <- rowMeans(data, na.rm = TRUE)
   center <- sum(sizes * statistics)/sum(sizes)
   list(statistics = statistics, center = center)
 }
@@ -629,7 +629,7 @@ sd.xbar <- function(data, sizes, std.dev = c("UWAVE-R", "UWAVE-SD", "MVLUE-R", "
 {
   data <- as.matrix(data)
   if(missing(sizes))
-    sizes <- apply(data, 1, function(x) sum(!is.na(x)))
+    sizes <- as.integer(rowSums(!is.na(data)))
   if(any(sizes == 1))
     stop("group sizes must be larger than one")
   if(!is.numeric(std.dev))
@@ -694,7 +694,7 @@ stats.S <- function(data, sizes)
 {
   data <- as.matrix(data)
   if (missing(sizes))
-     sizes <- apply(data, 1, function(x) sum(!is.na(x)))
+     sizes <- as.integer(rowSums(!is.na(data)))
   if(ncol(data)==1) 
     { statistics <- as.vector(data) }
   else 
@@ -740,7 +740,7 @@ stats.R <- function(data, sizes)
 {
   data <- as.matrix(data)
   if (missing(sizes))
-     sizes <- apply(data, 1, function(x) sum(!is.na(x)))
+     sizes <- as.integer(rowSums(!is.na(data)))
   if(ncol(data)==1) 
     { statistics <- as.vector(data) }
   else 
@@ -975,4 +975,3 @@ limits.u <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
   if (length(unique(sizes))==1) sizes <- sizes[1]
   limits.c(center * sizes, std.dev, sizes, nsigmas, conf) / sizes
 }
-

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -615,6 +615,14 @@ plot.qcc <- function(x, xtime = NULL,
 qcc.c4 <- function(n)
 { sqrt(2/(n - 1)) * exp(lgamma(n/2) - lgamma((n - 1)/2)) }
 
+# Returns limits in a consistent structure for use in limits.* functions
+.construct_limits <- function(lcl,ucl) {
+  limits <- matrix(c(lcl, ucl), ncol = 2)
+  rownames(limits) <- rep("", length = nrow(limits))
+  colnames(limits) <- c("LCL", "UCL")
+  return(limits)
+}
+
 # xbar
 
 stats.xbar <- function(data, sizes)
@@ -686,10 +694,7 @@ limits.xbar <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
           }
        else stop("invalid 'conf' argument. See help.")
      }
-  limits <- matrix(c(lcl, ucl), ncol = 2)
-  rownames(limits) <- rep("", length = nrow(limits))
-  colnames(limits) <- c("LCL", "UCL")
-  return(limits)
+  .construct_limits(lcl,ucl)
 }
 
 
@@ -736,10 +741,7 @@ limits.S <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
           }
           else stop("invalid conf argument. See help.")
      }
-  limits <- matrix(c(lcl, ucl), ncol = 2)
-  rownames(limits) <- rep("", length = nrow(limits))
-  colnames(limits) <- c("LCL", "UCL")
-  limits
+  .construct_limits(lcl,ucl)
 }
 
 # R Chart 
@@ -788,10 +790,7 @@ limits.R <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
           }
        else stop("invalid conf argument. See help.")
      }
-  limits <- matrix(c(lcl, ucl), ncol = 2)
-  rownames(limits) <- rep("", length = nrow(limits))
-  colnames(limits) <- c("LCL", "UCL")
-  return(limits)
+  .construct_limits(lcl,ucl)
 }
 
 # xbar Chart for one-at-time data
@@ -844,10 +843,7 @@ limits.xbar.one <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
           }
        else stop("invalid conf argument. See help.")
      }
-  limits <- matrix(c(lcl, ucl), ncol = 2)
-  rownames(limits) <- rep("", length = nrow(limits))
-  colnames(limits) <- c("LCL", "UCL")
-  return(limits)
+  .construct_limits(lcl,ucl)
 }
 
 
@@ -920,10 +916,7 @@ limits.np <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
           }
        else stop("invalid conf argument. See help.")
      }
-  limits <- matrix(c(lcl, ucl), ncol = 2)
-  rownames(limits) <- rep("", length = nrow(limits))
-  colnames(limits) <- c("LCL", "UCL")
-  return(limits)
+  .construct_limits(lcl,ucl)
 }
 
 # c Chart
@@ -962,10 +955,7 @@ limits.c <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
           }
        else stop("invalid conf argument. See help.")
      }
-  limits <- matrix(c(lcl, ucl), ncol = 2)
-  rownames(limits) <- rep("", length = nrow(limits))
-  colnames(limits) <- c("LCL", "UCL")
-  return(limits)
+  .construct_limits(lcl,ucl)
 }
 
 # u Chart

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -944,8 +944,7 @@ limits.c <- function(center, std.dev, sizes, nsigmas = NULL, conf = NULL)
   if(is.null(nsigmas) & is.null(conf))
     stop("Argument 'nsigmas' or 'conf' must be provided. See help.")
   if (is.null(conf))
-     { lcl <- center - nsigmas * sqrt(center)
-       lcl[lcl < 0] <- 0
+     { lcl <- pmax(0, center - nsigmas * sqrt(center))
        ucl <- center + nsigmas * sqrt(center)
      }
   else 

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -811,13 +811,13 @@ sd.xbar.one <- function(data, sizes, std.dev = c("MR", "SD"), r = 2, ...)
     { sd <- std.dev }
   else
     { switch(std.dev, 
-             "MR" = { d2 <- qcc.options("exp.R.unscaled")
-                      if(is.null(d2))
-                         stop(".qcc.options$exp.R.unscaled is null")
-                      d <- 0
-                      for(j in r:n)
-                          d <- d+abs(diff(range(data[c(j:(j-r+1))], na.rm=TRUE)))
-                      sd <- (d/(n-r+1))/d2[r] },
+             "MR" = {
+                d2 <- qcc.options("exp.R.unscaled")
+                moving_ranges <- apply(embed(data, r), 1L, function(x) {
+                  diff(range(x, na.rm = TRUE))
+                })
+                sd <- mean(moving_ranges) / d2[r]
+             },
              "SD" = { sd <- sd(data)/qcc.c4(n) },
              # "SD" = { sd <- sd(data, na.rm = TRUE)/qcc.c4(sum(!is.na(data))) }, # FIX: This handles NAs
              sd <- NULL)

--- a/R/qcc.R
+++ b/R/qcc.R
@@ -803,14 +803,14 @@ sd.xbar.one <- function(data, sizes, std.dev = c("MR", "SD"), r = 2, ...)
   else
     { switch(std.dev, 
              "MR" = {
+                data <- data[!is.na(data)]
                 d2 <- qcc.options("exp.R.unscaled")
                 moving_ranges <- apply(embed(data, r), 1L, function(x) {
-                  diff(range(x, na.rm = TRUE))
+                  diff(range(x))
                 })
                 sd <- mean(moving_ranges) / d2[r]
              },
-             "SD" = { sd <- sd(data)/qcc.c4(n) },
-             # "SD" = { sd <- sd(data, na.rm = TRUE)/qcc.c4(sum(!is.na(data))) }, # FIX: This handles NAs
+             "SD" = { sd <- sd(data, na.rm = TRUE)/qcc.c4(sum(!is.na(data))) },
              sd <- NULL)
     }
   return(sd)

--- a/R/rules.R
+++ b/R/rules.R
@@ -117,10 +117,10 @@ qccRulesViolatingWER2 <- function(object,
                                      nsigmas = k))
   i <- if(nrow(limits) > 1) seq(run.length, length(statistics)) else 1
   viol.above <- embed(statistics, run.length) > limits[i,2]
-  viol.above <- which(apply(viol.above, 1, sum) >= run.points & viol.above[,1])
+  viol.above <- which(rowSums(viol.above) >= run.points & viol.above[,1])
   viol.above <- viol.above + (run.length-1)
   viol.below <- embed(statistics, run.length) < limits[i,1]
-  viol.below <- which(apply(viol.below, 1, sum) >= run.points & viol.below[,1])
+  viol.below <- which(rowSums(viol.below) >= run.points & viol.below[,1])
   viol.below <- viol.below + (run.length-1)
   return(c(viol.above, viol.below))
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -4,6 +4,8 @@
 #                                                                   #
 #-------------------------------------------------------------------#
 
+# Remove this definition when the minimum supported R version becomes 4.4
+`%||%` <- function(x, y) if (is.null(x)) y else x
 qccGroups <- function(data, x, sample)
 {
   # collect x and sample from data if provided

--- a/tests/testthat/test-qcc.R
+++ b/tests/testthat/test-qcc.R
@@ -295,3 +295,41 @@ test_that("R-chart helpers keep expected structure and enforce max subgroup size
     "group size must be less than"
   )
 })
+
+test_that("sd.xbar.one: mean MR estimator produces expected estimate.", {
+  data <- c(100, 110, 95, 105, 98, 112, 101, 99, 107, 103)
+  estimate <- sd.xbar.one(data, std.dev = "MR")
+  expect_equal(estimate, 7.97872340)
+})
+
+test_that("sd.xbar.one: SD-based estimator produces expected estimate", {
+  data <- c(100, 110, 95, 105, 98, 112, 101, 99, 107, 103)
+  estimate <- sd.xbar.one(data, std.dev = "SD")
+  expect_equal(estimate, 5.61029128)
+})
+
+test_that("sd.xbar.one: Assume zero MRs for partially missing windows with the mean MR estimator", {
+  data <- c(100, 110, NA, 105, 98, 112)
+  estimate <- sd.xbar.one(data, std.dev = "MR")
+  expect_equal(estimate, 5.49645390)
+})
+
+# FIX: This behaviour is unexpected
+test_that("sd.xbar.one: Return Inf for completely missing windows", {
+  data <- c(100, 110, NA, NA, 98, 112)
+  suppressWarnings(expect_warning(estimate <- sd.xbar.one(data, std.dev = "MR"), "Inf"))
+  expect_equal(estimate, Inf)
+})
+
+# FIX: This behaviour feels unexpected. Not sure.
+test_that("sd.xbar.one: Return NA for missing data using the SD-based estimator", {
+  data <- c(100, 110, NA, 105, 98, 112)
+  estimate <- sd.xbar.one(data, std.dev = "SD")
+  expect_true(is.na(estimate))
+})
+
+test_that("sd.xbar.one: mean MR estimator accepts r != 2.", {
+  data <- c(100, 110, 95, 105, 98, 112, 101, 99, 107, 103)
+  estimate <- sd.xbar.one(data, std.dev = "MR", r = 3)
+  expect_equal(estimate, 7.16184288)
+})

--- a/tests/testthat/test-qcc.R
+++ b/tests/testthat/test-qcc.R
@@ -318,7 +318,7 @@ test_that("sd.xbar.one: Assume zero MRs for partially missing windows with the m
 test_that("sd.xbar.one: Return Inf for completely missing windows", {
   data <- c(100, 110, NA, NA, 98, 112)
   suppressWarnings(expect_warning(estimate <- sd.xbar.one(data, std.dev = "MR"), "Inf"))
-  expect_equal(estimate, Inf)
+  expect_equal(estimate, -Inf)
 })
 
 # FIX: This behaviour feels unexpected. Not sure.

--- a/tests/testthat/test-qcc.R
+++ b/tests/testthat/test-qcc.R
@@ -311,21 +311,19 @@ test_that("sd.xbar.one: SD-based estimator produces expected estimate", {
 test_that("sd.xbar.one: Assume zero MRs for partially missing windows with the mean MR estimator", {
   data <- c(100, 110, NA, 105, 98, 112)
   estimate <- sd.xbar.one(data, std.dev = "MR")
-  expect_equal(estimate, 5.49645390)
+  expect_equal(estimate, 7.97872340)
 })
 
-# FIX: This behaviour is unexpected
 test_that("sd.xbar.one: Return Inf for completely missing windows", {
   data <- c(100, 110, NA, NA, 98, 112)
-  suppressWarnings(expect_warning(estimate <- sd.xbar.one(data, std.dev = "MR"), "Inf"))
-  expect_equal(estimate, -Inf)
+  expect_no_warning(estimate <- sd.xbar.one(data, std.dev = "MR"))
+  expect_equal(estimate, 10.6382979)
 })
 
-# FIX: This behaviour feels unexpected. Not sure.
 test_that("sd.xbar.one: Return NA for missing data using the SD-based estimator", {
   data <- c(100, 110, NA, 105, 98, 112)
   estimate <- sd.xbar.one(data, std.dev = "SD")
-  expect_true(is.na(estimate))
+  expect_equal(estimate, 6.471123)
 })
 
 test_that("sd.xbar.one: mean MR estimator accepts r != 2.", {


### PR DESCRIPTION
- Use `x %||% y` instead of `if(is.null(x)) y else x`. abefc6a63e561d88192425247bb7e56794da6ecb
- add test fixtures for `sd.xbar.one` after identifying potential bugs. dccea890112db9e1a0b63ce769e354b3dfce2f3a
- Extract `.construct_limits` function from `limits.*` functions to prevent drift. 0120a6e1d1cb5450e99ab52372247ef971eacc2d
- reduce number of computations for `limits.xbar` and `limits.xbar.one`. 0be46856c965adede84290192570153e0c51a9ea
- rewrote the MR estimator of `sd.xbar.one` for readability, *preserving a potential bug*. f60a8b087c630610c02ab7da6b85d1edad657912 
- rewrote `limits.c` for readability. 7e0f4a59a6ed7078875a47a012619cd03f9792f4
- Use the same minimum R version used by the dependency `ggplot2 >= 4.0`. 0543e312c7052e163b2fc14ca1ad61e954bf9e1f
- refactor `ggplot2` theme settings in `plot.*` that use `ggplot2`. Prevents drift and improves readability. 9c7e3146c4dde600d107bfcce013055c787c1b35
- Handle NAs correctly in `sd.xbar.one`. implemented in 162c4bec1e7679568d242de7504775aaaab8be15 and discussed in https://github.com/luca-scr/qcc/pull/62#issuecomment-4721421561
- Replace some `apply()` expressions with specialized functions (e.g. `rowMeans`, `rowSums`). discussed in https://github.com/luca-scr/qcc/pull/62#issuecomment-4830644037 and implemented in [79acf23](https://github.com/luca-scr/qcc/pull/62/commits/79acf2375445171e9ef1b4ee246b13cd705f6cc1)